### PR TITLE
Send email address instead if id to journal.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.0.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Send email address instead if id to journal.
+  [mathias.leimgruber]
 
 
 2.0.6 (2013-08-28)

--- a/ftw/notification/email/events/handlers.py
+++ b/ftw/notification/email/events/handlers.py
@@ -2,10 +2,31 @@ from DateTime import DateTime
 from ftw.journal.events.events import JournalEntryEvent
 from ftw.notification.base import notification_base_factory as _
 from ftw.notification.base.interfaces import INotifier
+from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
+from zope.component import hooks
 from zope.component import queryUtility
 from zope.event import notify
 from zope.i18n import translate
+
+
+def get_emails_from_ids(ids):
+    site = hooks.getSite()
+    portal_membership = getToolByName(site, 'portal_membership')
+    result = []
+
+    for id_ in ids:
+        member = portal_membership.getMemberById(id_)
+        if not member:
+            result.append(id_)
+            continue
+
+        email = member.getProperty('email', id_)
+        if not email:
+            result.append(id_)
+        else:
+            result.append(email)
+    return result
 
 
 def notification_sent(event):
@@ -36,13 +57,15 @@ def notification_sent(event):
     to_list = obj.REQUEST.get('to_list', [])
     cc_list = obj.REQUEST.get('cc_list', [])
 
+    readable_to = get_emails_from_ids(to_list)
+    readable_cc = get_emails_from_ids(cc_list)
     journal_comment = translate(
         msgid=u'journal_notification_text',
         domain='ftw.notification.email',
         context=obj.REQUEST,
         mapping=dict(
-            to_list=len(to_list) > 0 and ', '.join(to_list) + '\n' or '-',
-            cc_list=len(cc_list) > 0 and ', '.join(cc_list) + '\n' or '-',
+            to_list=len(to_list) > 0 and ', '.join(readable_to) + '\n' or '-',
+            cc_list=len(cc_list) > 0 and ', '.join(readable_cc) + '\n' or '-',
             comment=comment))
 
     notify(JournalEntryEvent(obj, journal_comment, action))

--- a/ftw/notification/email/tests/notification.txt
+++ b/ftw/notification/email/tests/notification.txt
@@ -95,3 +95,25 @@ create the message object:
     >>> mailhost.smtp_host
     ''
     >>> mailhost.send(email.as_string(), 'v.baumann@4teamwork.ch', 'test@localhost', 'Subject')
+
+
+Extract email addresses from ids
+
+    >>> from ftw.notification.email.events.handlers import get_emails_from_ids
+
+No email address, returns the userid
+    >>> get_emails_from_ids([TEST_USER_ID])
+    ['test_user_1_']
+
+Return email
+    >>> regtool = getToolByName(portal, 'portal_registration')
+    >>> user = regtool.addMember('user', 'password',
+    ...                          properties={'username': 'User',
+    ...                                     'fullname': 'fullname',
+    ...                                     'email': 'user@email.com'})
+    >>> user2 = regtool.addMember('user2', 'password',
+    ...                           properties={'username': 'User',
+    ...                                       'fullname': 'fullname',
+    ...                                       'email': 'user2@email.com'})
+    >>> get_emails_from_ids(['user', 'user2'])
+    ['user@email.com', 'user2@email.com']


### PR DESCRIPTION
It makes sense if we put the email address into the journal instead of the id. 
![screen shot 2013-10-22 at 11 45 46 am](https://f.cloud.github.com/assets/437933/1380071/c373a262-3afe-11e3-918b-c0b86643f053.png)
