### PR TITLE
Add content id support

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add content ID support [Nachtalb]
 
 
 2.1.0 (2016-11-30)

--- a/ftw/notification/email/composer.py
+++ b/ftw/notification/email/composer.py
@@ -223,7 +223,7 @@ class HTMLComposer(persistent.Persistent):
         return html
 
     def render(self, override_vars=None, template_vars=_marker,
-               attachments=_marker, **kwargs):
+               attachments=_marker, images=None, **kwargs):
 
         if template_vars is _marker:
             template_vars = {}
@@ -246,6 +246,7 @@ class HTMLComposer(persistent.Persistent):
             to_addr=variables['to_addr'],
             headers=variables.get('more_headers'),
             encoding=self.encoding,
-            attachments=attachments)
+            attachments=attachments,
+            images=images)
 
         return message

--- a/ftw/notification/email/composer.py
+++ b/ftw/notification/email/composer.py
@@ -1,6 +1,7 @@
 from email import Encoders
 from email import Utils
 from email.MIMEBase import MIMEBase
+from email.MIMEImage import MIMEImage
 from email.MIMEMultipart import MIMEMultipart
 from email.MIMEText import MIMEText
 from email.Utils import formatdate
@@ -29,10 +30,18 @@ _marker = object()
 
 
 def create_html_mail(subject, html, text=None, from_addr=None, to_addr=None,
-                     headers=None, encoding='UTF-8', attachments=_marker):
+                     headers=None, encoding='UTF-8', attachments=_marker,
+                     images=None):
     """Create a mime-message that will render HTML in popular
     MUAs, text in better ones.
+
+    :param images: List[Tuple[file, contentid, subtype], ..] where file can be
+        bytes or a filelike object, contentid the id which will be referencable
+        in the HTML with <img src="cid:{contentid}" /> without the curly
+        brackets and subtype the latter part of the mimetype eg. "png" from
+        "image/png"
     """
+    images = images or []
 
     if attachments is _marker:
         attachments = []
@@ -85,6 +94,16 @@ def create_html_mail(subject, html, text=None, from_addr=None, to_addr=None,
     related.attach(alternatives)
     alternatives.attach(MIMEText(text, 'plain', _charset=encoding))
     alternatives.attach(MIMEText(html, 'html', _charset=encoding))
+
+    for fio, contentid, subtype in images:
+        if hasattr('read', fio):
+            data = fio.read()
+        else:
+            data = fio
+
+        image = MIMEImage(data, subtype)
+        image.add_header('Content-ID', '<%s>' % contentid)
+        related.attach(image)
 
     # add the attachments
     for f, name, mimetype in attachments:

--- a/ftw/notification/email/composer.py
+++ b/ftw/notification/email/composer.py
@@ -78,8 +78,11 @@ def create_html_mail(subject, html, text=None, from_addr=None, to_addr=None,
 
     msg.preamble = 'This is a multi-part message in MIME format.'
 
+    related = MIMEMultipart('related')
+    msg.attach(related)
+
     alternatives = MIMEMultipart('alternative')
-    msg.attach(alternatives)
+    related.attach(alternatives)
     alternatives.attach(MIMEText(text, 'plain', _charset=encoding))
     alternatives.attach(MIMEText(html, 'html', _charset=encoding))
 


### PR DESCRIPTION
Add images to email with either 
```python
hmtl = """
<p>Foo Bar</p>
<img src="cid:logo" />
<img src="cid:image2" />
"""

logo = open('../images/logo.png')
image2 = context.image.data  # context.image is a plone.namedfile.file.NamedBlobImage in this case 
image2_subtype = context.image.contentType.split('/')[1]

mail_images = [
    (logo, 'logo', 'png'),
    (image2, 'image2', image2_subtype),
]

create_html_mail("My Subject", html=html, to_addr='chuck@norris.gov', images=mail_images)
```

or with the HTMLComposer like this: 
```python
composer = HTMLComposer(html, subject, 'chuck@norris.gov', images=mail_images)
```

Due to the age of this package and because no tests were written for the `HTMLComposer` nor the `create_html_mail` function I haven't added tests for this. But I did tests it manually on an existing policy which will be using this functionality. 